### PR TITLE
Keep the rptfile open for the duration of the run

### DIFF
--- a/rr.pl
+++ b/rr.pl
@@ -74,6 +74,7 @@ my $plugindir;
 ($^O eq "MSWin32") ? ($plugindir = $str."plugins/")
                    : ($plugindir = File::Spec->catfile("plugins"));
 my @alerts = ();
+my $RPTFH;
 
 #-----------------------------------------------------------
 # GUI
@@ -248,6 +249,8 @@ sub browse2_Click {
 sub go_Click {	
 # Set up the environment
 	setUpEnv();
+	open($RPTFH,">>",$env{rptfile});
+	binmode $RPTFH,":utf8";
 	if ($env{ntuser} eq "") {
 		Win32::GUI::MessageBox($main,$ENV{USERNAME}.", you did not select a hive file.\r\n",
 		                       "Doh!!",16);
@@ -344,6 +347,7 @@ sub go_Click {
 	}
 
 	$report->Append($err_cnt." plugins completed with errors.\r\n");
+	close($RPTFH);
 	$status->Text("Done.");
 }
 
@@ -396,10 +400,10 @@ sub logMsg {
 }
 
 sub rptMsg {
-	open(FH,">>",$env{rptfile});
-	binmode FH,":utf8";
+	#open(FH,">>",$env{rptfile});
+	#binmode FH,":utf8";
 	print FH $_[0]."\n";
-	close(FH);
+	#close(FH);
 }
 
 sub alertMsg {


### PR DESCRIPTION
I got some reports of slow runs, in particular while running the clsid.pl plugin. This wasn't appearing on all systems. It appears that the problem was attributable to opening and closing the handle to the logfile. That said, I have only tested under Strawberry Perl as I don't have perl2exe available.

Thoughts?