### PR TITLE
Fix multibyte character corruption in wordwheelquery.pl

### DIFF
--- a/plugins/wordwheelquery.pl
+++ b/plugins/wordwheelquery.pl
@@ -3,6 +3,7 @@
 # For Windows 7
 #
 # Change history
+#   20200823 - fixed multibyte character corruption
 #   20200526 - updated date output format
 #	  20100330 - created
 #
@@ -13,13 +14,14 @@
 #-----------------------------------------------------------
 package wordwheelquery;
 use strict;
+use Encode::Unicode;
 
 my %config = (hive          => "NTUSER\.DAT",
               hasShortDescr => 1,
               hasDescr      => 0,
               hasRefs       => 0,
               osmask        => 22,
-              version       => 20200526);
+              version       => 20200823);
 
 sub getConfig{return %config}
 sub getShortDescr {
@@ -58,7 +60,9 @@ sub pluginmain {
 				}
 				else {
 					my $data = $v->get_data();
-					$data =~ s/\00//g;
+					Encode::from_to($data,'UTF-16LE','utf8');
+					$data = Encode::decode_utf8($data);
+					chop $data;
 					$wwq{$name} = $data;
 				}
 			}


### PR DESCRIPTION
**Description of problem:**

When processing NTUSER.dat exported from Japanese version of Windows by `wordwheelquery` plugin, I got corrupted multibyte characters in the output.

**Test and Outputs:**

***Test 1 (original):***

Before updating `wordwheelquery.pl`, I ran the following command.

```
rip -r NTUSER.DAT -p wordwheelquery > wordwheelquery.txt
```

Then I got the following output which contains corrupted multibyte characters in `wordwheelquery.txt`.

```
Searches listed in MRUListEx order

65   °emD}                        
64   ¨0¢0³0ó0                      
43   mv5                           
63   IMG_0070                      
62   q,g                          
```

***Test 2 (patched):***

After updating `wordwheelquery.pl`, I ran the same command as Test 1 to the same NTUSER.DAT.

Then I got the following output which contains valid UTF-8 Japanese characters in `wordwheelquery.txt`.

```
Searches listed in MRUListEx order

65   新洗組                           
64   エアコン                          
43   mv5                           
63   IMG_0070                      
62   熊本                            
```

***Test 3 (Registry Explorer):***

To confirm the output in another tool, I opened the same NTUSER.DAT by Eric Zimmerman's Registry Explorer. You can see the same characters as in Test 2.

![clip_20200823_152144](https://user-images.githubusercontent.com/5938690/90972964-a7018980-e558-11ea-8466-ab7c87f52aef.png)

**Operating system RegRipper is running on:**

Windows 10 (1909), Japanese version

**Operating system RegRipper is processing to:**

Windows 10 (1909), Japanese version

**Source data:**

WordWheelQuery key: [WordWheelQuery.zip](https://github.com/keydet89/RegRipper3.0/files/5113610/WordWheelQuery.zip)

This is an exported registry key. To use this data for test, please import this to your registry first.