### PR TITLE
Fix multibyte character corruption in wordwheelquery_tln.pl

### DIFF
--- a/plugins/wordwheelquery_tln.pl
+++ b/plugins/wordwheelquery_tln.pl
@@ -3,6 +3,7 @@
 # For Windows 7+
 #
 # Change history
+#   20200824 - fixed multibyte character corruption
 #   20200325 - created, copied from wordwheelquery.pl
 #	  20100330 - original plugin created
 #
@@ -13,13 +14,14 @@
 #-----------------------------------------------------------
 package wordwheelquery_tln;
 use strict;
+use Encode::Unicode;
 
 my %config = (hive          => "NTUSER\.DAT",
               hasShortDescr => 1,
               hasDescr      => 0,
               hasRefs       => 0,
               osmask        => 22,
-              version       => 20200325);
+              version       => 20200824);
 
 sub getConfig{return %config}
 sub getShortDescr {
@@ -52,7 +54,9 @@ sub pluginmain {
 			my @list = unpack("V*",$data);
 			if ($list[0] != 0xffffffff) {
 				$search = $key->get_value($list[0])->get_data();
-				$search =~ s/\00//g;
+				Encode::from_to($search,'UTF-16LE','utf8');
+				$search = Encode::decode_utf8($search);
+				chop $search;
 			} 
 			::rptMsg($lw."|REG|||WordWheelQuery most recent search: ".$search);
 		}


### PR DESCRIPTION
**Description of problem:**

This is the same problem as [Pull Request #7](https://github.com/keydet89/RegRipper3.0/pull/7).

When processing NTUSER.dat exported from Japanese version of Windows by `wordwheelquery_tln` plugin, I got corrupted multibyte characters in the output.

**Test and Outputs:**

***Test 1 (original):***

Before updating `wordwheelquery_tln.pl`, I ran the following command.

```
rip -r NTUSER.DAT -p wordwheelquery_tln > wordwheelquery_tln.txt
```

Then I got the following output which contains corrupted multibyte characters in `wordwheelquery_tln.txt`.

```
1597540907|REG|||WordWheelQuery most recent search: 属emD}
```

***Test 2 (patched):***

After updating `wordwheelquery_tln.pl`, I ran the same command as Test 1 to the same NTUSER.DAT.

Then I got the following output which contains valid UTF-8 Japanese characters in `wordwheelquery_tln.txt`.

```
1597540907|REG|||WordWheelQuery most recent search: 新洗組
```

**Operating system RegRipper is running on:**

Windows 10 (1909), Japanese version

**Operating system RegRipper is processing to:**

Windows 10 (1909), Japanese version

**Source data:**

WordWheelQuery key: [WordWheelQuery.zip](https://github.com/keydet89/RegRipper3.0/files/5117351/WordWheelQuery.zip)

This is the same data as [Pull Request #7](https://github.com/keydet89/RegRipper3.0/pull/7). To use this data for test, please import this to your registry first.