### PR TITLE
Fix multibyte character corruption in samparse_tln.pl

### DIFF
--- a/plugins/samparse_tln.pl
+++ b/plugins/samparse_tln.pl
@@ -3,6 +3,7 @@
 # Parse the SAM hive file for user/group membership info
 #
 # Change history:
+#    20200826 - fixed multibyte character corruption
 #    20120827 - TLN version created from original samparse.pl
 #    20120722 - updated %config hash
 #    20110303 - Fixed parsing of SID, added check for account type
@@ -23,6 +24,7 @@
 #-----------------------------------------------------------
 package samparse_tln;
 use strict;
+use Encode::Unicode;
 
 my %config = (hive          => "SAM",
               hivemask      => 2,
@@ -34,7 +36,7 @@ my %config = (hive          => "SAM",
               hasShortDescr => 1,
               hasDescr      => 0,
               hasRefs       => 1,
-              version       => 20120827);
+              version       => 20200826);
 
 sub getConfig{return %config}
 
@@ -121,7 +123,7 @@ sub pluginmain {
 					my $c_descr = "Acct Created (".$v_val{type}.")";
 					eval {
 						$pw_hint = $u->get_value("UserPasswordHint")->get_data();
-						$pw_hint =~ s/\00//g;
+						$pw_hint = _uniToAscii($pw_hint);
 						$c_descr .= " (Pwd Hint: ".$pw_hint.")";
 					};
 					
@@ -278,7 +280,8 @@ sub _translateSID {
 #---------------------------------------------------------------------
 sub _uniToAscii {
   my $str = $_[0];
-  $str =~ s/\00//g;
+  Encode::from_to($str,'UTF-16LE','utf8');
+  $str = Encode::decode_utf8($str);
   return $str;
 }
 


### PR DESCRIPTION
**Description of problem:**

This is the same problem as [Pull Request #9](https://github.com/keydet89/RegRipper3.0/pull/9).

When processing a `SAM` exported from Japanese version of Windows by `samparse_tln` plugin, I got corrupted multibyte characters in the output.

**Test and Outputs:**

***Test 1 (original):***

Before updating `samparse_tln.pl`, I ran the following command.

```
rip -r SAM -p samparse_tln > samparse_tln_before.txt
```

Then I got the following output which contains corrupted multibyte characters in `samparse_tln_before.txt`.

```
1598439406|SAM||æ0ü0¶0ü0|Password Reset Date
1598439425|SAM||æ0ü0¶0ü0|Last Login (2)
```

***Test 2 (patched):***

After updating `samparse_tln.pl`, I ran the following command to the same `SAM` as Test 1.
```
rip -r SAM -p samparse_tln > samparse_tln_after.txt
```

Then I got the following output which contains valid UTF-8 Japanese characters in `samparse_tln_after.txt`.

```
1598439406|SAM||ユーザー|Password Reset Date
1598439425|SAM||ユーザー|Last Login (2)
```

**Operating system RegRipper is running on:**

Windows 10 (1909), Japanese version

**Operating system RegRipper is targeting to:**

Windows 10 (1909), Japanese version

**Data:**

* [SAM.zip](https://github.com/keydet89/RegRipper3.0/files/5129627/SAM.zip)
* [samparse_tln_before.txt](https://github.com/keydet89/RegRipper3.0/files/5129629/samparse_tln_before.txt)
* [samparse_tln_after.txt](https://github.com/keydet89/RegRipper3.0/files/5129630/samparse_tln_after.txt)

The `SAM` is the same data as [a comment of Pull Request #9](https://github.com/keydet89/RegRipper3.0/pull/9#issuecomment-680819038).