### PR TITLE
add GPT partition GUID support

### DIFF
--- a/plugins/mountdev.pl
+++ b/plugins/mountdev.pl
@@ -74,7 +74,12 @@ sub pluginmain {
 			
 			::rptMsg("");
 			foreach my $m (keys %md) {
-				::rptMsg("Device: ".$m);
+				if ($m =~ /^DMIO:ID:/){
+					::rptMsg("Device: DMIO:ID:"._translateBinary(substr($m,8)));
+				}
+				else {
+					::rptMsg("Device: ".$m);
+				}
 				foreach my $item (@{$md{$m}}) {
 					::rptMsg("  ".$item);
 				}


### PR DESCRIPTION
When the device key starts with 'DMIO:ID:', it is
followed by 16 bytes that are the partition GUID.
Those bytes most likely will not be printable and
are better shown in hexadecimal.