### PR TITLE
Fix version printing in different plugins

### DIFF
--- a/plugins/adobe.pl
+++ b/plugins/adobe.pl
@@ -51,7 +51,6 @@ sub pluginmain {
   ::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); 
 	my $reg = Parse::Win32Registry->new($ntuser);
 	my $root_key = $reg->get_root_key;
-	::rptMsg("adobe v.".$VERSION);
 	
 	my @apps = ("Adobe Acrobat","Acrobat Reader");
 	foreach my $app (@apps) {

--- a/plugins/appcertdlls.pl
+++ b/plugins/appcertdlls.pl
@@ -42,6 +42,7 @@ sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
 	::logMsg("Launching appcertdlls v.".$VERSION);
+	::rptMsg("appcertdlls v.".$VERSION);
 	my $reg = Parse::Win32Registry->new($hive);
 	my $root_key = $reg->get_root_key;
 # First thing to do is get the ControlSet00x marked current...this is

--- a/plugins/appinitdlls.pl
+++ b/plugins/appinitdlls.pl
@@ -43,7 +43,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching appinitdlls v.".$VERSION);
+	::logMsg("Launching appinitdlls v.".$VERSION);
 	::rptMsg("appinitdlls v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
 	my @paths = ('Microsoft\\Windows NT\\CurrentVersion\\Windows',

--- a/plugins/audiodev.pl
+++ b/plugins/audiodev.pl
@@ -41,7 +41,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching audiodev v.".$VERSION);
+	::logMsg("Launching audiodev v.".$VERSION);
 	::rptMsg("audiodev v.".$VERSION); 
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); 
 	my $key_path = 'Microsoft\\Windows\\CurrentVersion\\MMDevices\\Audio';

--- a/plugins/execpolicy.pl
+++ b/plugins/execpolicy.pl
@@ -36,7 +36,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching execpolicy v.".$VERSION);
+	::logMsg("Launching execpolicy v.".$VERSION);
 	::rptMsg("execpolicy v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
 	my $key_path = ('Microsoft\\PowerShell\\1\\ShellIds\\Microsoft.Powershell');

--- a/plugins/killsuit.pl
+++ b/plugins/killsuit.pl
@@ -36,7 +36,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching killsuit v.".$VERSION);
+	::logMsg("Launching killsuit v.".$VERSION);
 	::rptMsg("killsuit v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); 
 	my $key_path = ('Microsoft\\Windows\\CurrentVersion\\OemMgmt');

--- a/plugins/listsoft.pl
+++ b/plugins/listsoft.pl
@@ -45,7 +45,6 @@ sub pluginmain {
 	my $key_path = 'Software';
 	my $key;
 	if ($key = $root_key->get_subkey($key_path)) {
-		::rptMsg("listsoft v.".$VERSION);
 		::rptMsg("List the contents of the Software key in the NTUSER\.DAT hive");
 		::rptMsg("file, in order by LastWrite time.");
 		::rptMsg("");

--- a/plugins/netsh.pl
+++ b/plugins/netsh.pl
@@ -37,7 +37,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching netsh v.".$VERSION);
+	::logMsg("Launching netsh v.".$VERSION);
 	::rptMsg("netsh v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
 	my $key_path = 'Microsoft\\Netsh';

--- a/plugins/rdpport.pl
+++ b/plugins/rdpport.pl
@@ -46,8 +46,6 @@ sub pluginmain {
 	my $ccs = $root_key->get_subkey("Select")->get_value("Current")->get_data();
 	my $key_path = "ControlSet00".$ccs."\\Control\\Terminal Server\\WinStations\\RDP-Tcp";
 	if ($key = $root_key->get_subkey($key_path)) {
-		::rptMsg("rdpport v.".$VERSION);
-		::rptMsg("");
 		my $port;
 		eval {
 			$port = $key->get_value("PortNumber")->get_data();

--- a/plugins/runonceex.pl
+++ b/plugins/runonceex.pl
@@ -36,7 +36,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching runonceex v.".$VERSION);
+	::logMsg("Launching runonceex v.".$VERSION);
 	::rptMsg("runonceex v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
 	my $key_path = ('Microsoft\\Windows\\CurrentVersion\\RunOnceEx');

--- a/plugins/sfc.pl
+++ b/plugins/sfc.pl
@@ -44,8 +44,6 @@ sub pluginmain {
 	my $key_path = "Microsoft\\Windows NT\\CurrentVersion\\Winlogon";
 	my $key;
 	if ($key = $root_key->get_subkey($key_path)) {
-		::rptMsg("sfc v.".$VERSION);
-		::rptMsg("");
 		::rptMsg($key_path);
 		::rptMsg("LastWrite Time ".::getDateFromEpoch($key->get_timestamp())."Z");
 		::rptMsg("");

--- a/plugins/srum.pl
+++ b/plugins/srum.pl
@@ -36,7 +36,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching srum v.".$VERSION);
+	::logMsg("Launching srum v.".$VERSION);
 	::rptMsg("srum v.".$VERSION);
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); 
 	my $key_path = ('Microsoft\\Windows NT\\CurrentVersion\\SRUM\\Extensions');

--- a/plugins/thispcpolicy.pl
+++ b/plugins/thispcpolicy.pl
@@ -42,7 +42,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching thispcpolicy v.".$VERSION);
+	::logMsg("Launching thispcpolicy v.".$VERSION);
 	::rptMsg("thispcpolicy v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
 	

--- a/plugins/watp.pl
+++ b/plugins/watp.pl
@@ -37,7 +37,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching watp v.".$VERSION);
+	::logMsg("Launching watp v.".$VERSION);
 	::rptMsg("watp v.".$VERSION); # banner
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
 	my $key_path = ('Microsoft\\Windows Advanced Protection');

--- a/plugins/wow64.pl
+++ b/plugins/wow64.pl
@@ -37,7 +37,7 @@ my $VERSION = getVersion();
 sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
-	::rptMsg("Launching wow64 v.".$VERSION);
+	::logMsg("Launching wow64 v.".$VERSION);
 	::rptMsg("wow64 v.".$VERSION); 
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); 
 	my @paths = ('Microsoft\\WOW64\\x86','Microsoft\\WOW64\\arm');

--- a/plugins/wsh_settings.pl
+++ b/plugins/wsh_settings.pl
@@ -37,7 +37,7 @@ sub pluginmain {
 	my $class = shift;
 	my $hive = shift;
 	my ($name,$data);
-	::rptMsg("Launching wsh_settings v.".$VERSION);
+	::logMsg("Launching wsh_settings v.".$VERSION);
 	::rptMsg("wsh_settings v.".$VERSION); 
 	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n");  
 	my $key_path = ('Microsoft\\Windows Script Host\\Settings');


### PR DESCRIPTION
Cleanup version printing in multiple plugins, rename rptMsg to logMsg for "Launching ..." messages, remove duplicate version printing or add report message for version where it was missing.

I was analyzing a lot of RR output files and made a [Vim folding command](https://gist.github.com/Karneades/3d6643abf72a6a8731385e57d6ce9262) to fold the RegRipper plugin section inside Vim to better navigate through the output, this folding showed these duplicate version messages.

fyi this is how the folding looks like in Vim, makes jumping between plugin output much easier. And yes, I read in your blog many times that mostly use specific plugins individually and target specific information using single plugins ;)

![rr-folding](https://user-images.githubusercontent.com/30265053/107387082-c6837300-6af4-11eb-85de-4d2274739b5e.png)