### PR TITLE
Correct encoding issue - transform to UTF-8

### DIFF
--- a/plugins/allowedenum.pl
+++ b/plugins/allowedenum.pl
@@ -1,11 +1,11 @@
 #-----------------------------------------------------------
 # allowedenum.pl
 #   
-#  To whitelist or show “Documents”, add the GUID {FDD39AD0-238F-46AF-ADB4-6C85480369C7} 
-#  and set its value data to 1. To hide “Documents” remove the GUID value, or set its 
+#  To whitelist or show 'Documents', add the GUID {FDD39AD0-238F-46AF-ADB4-6C85480369C7}
+#  and set its value data to 1. To hide 'Documents' remove the GUID value, or set its
 #  data to 0.
 #
-# If the “AllowedEnumeration” key exists without any whitelisted entries, none of the 
+# If the 'AllowedEnumeration' key exists without any whitelisted entries, none of the
 # special folders will show up in File Explorer and Desktop.
 #
 # Value name, or GUID, represents special folder namespace; data of 1 == show, 0 == hidden

--- a/plugins/mountdev2.pl
+++ b/plugins/mountdev2.pl
@@ -5,7 +5,7 @@
 # 
 # Change history
 #   20200517 - updated date output format
-#   20140721 - update provided by Espen Øyslebø <eoyslebo@gmail.com>
+#   20140721 - update provided by Espen Ã˜yslebÃ¸ <eoyslebo@gmail.com>
 #   20130530 - updated to output Disk Signature in correct format, thanks to
 #              info provided by Tom Yarrish (see ref.)
 #   20120403 - commented out time stamp info from volume GUIDs, added
@@ -23,7 +23,7 @@ package mountdev2;
 use strict;
 
 # Required for 32-bit versions of perl that don't support unpack Q
-# update provided by Espen Øyslebø <eoyslebo@gmail.com>
+# update provided by Espen Ã˜yslebÃ¸ <eoyslebo@gmail.com>
 my $little;
 BEGIN { $little= unpack "C", pack "S", 1; }
 sub squad {
@@ -90,7 +90,7 @@ sub pluginmain {
 				if ($len == 12) {
 					my $sig = _translateBinary(substr($data,0,4));
 
-# Section added by Espen Øyslebø <eoyslebo@gmail.com>
+# Section added by Espen Ã˜yslebÃ¸ <eoyslebo@gmail.com>
 # gets the offset, which can be a value larger than what
 # can be handled by 32-bit Perl
 					my $o; #offset

--- a/plugins/uac.pl
+++ b/plugins/uac.pl
@@ -53,7 +53,7 @@ sub pluginmain {
         ::rptMsg("LastWrite Time: ".::getDateFromEpoch($key->get_timestamp())."Z");
         ::rptMsg("");
 
-        # GET EnableLUA –
+        # GET EnableLUA -
 
         my $enablelua;
         eval {
@@ -71,7 +71,7 @@ sub pluginmain {
         }
         ::rptMsg("");
 
-# GET EnableVirtualization –
+# GET EnableVirtualization -
 
         my $enablevirtualization;
         eval {
@@ -89,7 +89,7 @@ sub pluginmain {
         }
         ::rptMsg("");
 		
-		# GET FilterAdministratorToken –
+		# GET FilterAdministratorToken -
 
         my $filteradministratortoken;
         eval {
@@ -107,7 +107,7 @@ sub pluginmain {
         }
         ::rptMsg("");
 		
-		# GET ConsentPromptBehaviorAdmin –
+		# GET ConsentPromptBehaviorAdmin -
 
         my $consentpromptbehavioradmin;
         eval {
@@ -129,7 +129,7 @@ sub pluginmain {
         }
         ::rptMsg("");
 		
-		# GET ConsentPromptBehaviorUser –
+		# GET ConsentPromptBehaviorUser -
 
         my $consentpromptbehavioruser;
         eval {


### PR DESCRIPTION
Dear Harlan, 

I am submitting a small patch, which corrects the encoding of the following three files:

- plugins/allowedenum.pl
- plugins/mountdev2.pl
- plugins/uac.pl

These three files contain non-UTF-8 characters, which could be problematic, when using `regripper` on Linux. Therefore I would like to kindly ask you to incorporate this patch, which replaces those problematic character by their (closest) unicode representation. 

Best regards,
jgru

P.S.: Thank you for your great work on regripper!