### PR TITLE
Fix regex error stemming from unescaped braces

### DIFF
--- a/plugins/mountdev2.pl
+++ b/plugins/mountdev2.pl
@@ -121,10 +121,10 @@ sub pluginmain {
 			}
 			::rptMsg("");
 			foreach my $v (sort keys %vol) {
-				next unless ($v =~ m/^\\\?\?\\Volume{/);
+				next unless ($v =~ m/^\\\?\?\\Volume\{/);
 				my $id = $v;
-				$id =~ s/^\\\?\?\\Volume{//;
-				$id =~ s/}$//;
+				$id =~ s/^\\\?\?\\Volume\{//;
+				$id =~ s/\}$//;
 				$id =~ s/-//g;
 				my $l = hex(substr($id,0,8));
 				my $m = hex(substr($id,8,4));
@@ -142,8 +142,8 @@ sub pluginmain {
 					
 					if ($item =~ m/^\\\?\?\\Volume/) {
 						my $id = $item;
-						$id =~ s/^\\\?\?\\Volume{//;
-						$id =~ s/}$//;
+						$id =~ s/^\\\?\?\\Volume\{//;
+						$id =~ s/\}$//;
 #						$id =~ s/-//g;
 #						my $l = hex(substr($id,0,8));
 #						my $m = hex(substr($id,8,4));


### PR DESCRIPTION
Dear Harlan,

running the plugin `mountdev2.pl` throws the below mentioned error message due to unescaped curly braces. 
The following command was run under Ubuntu 18.04 and Debian 10: 
```
rip -r share/ntuser.dat/ntuser.dat -p mountdev2
```
This leads to the following error message:
```
[snip]
Error in /usr/local/share/regripper/plugins/mountdev2.pl: Unescaped left brace in regex is illegal here in regex; marked by <-- HERE in m/^\\\?\?\\Volume{ <-- HERE / at /usr/local/share/regripper/plugins/mountdev2.pl line 124.
Compilation failed in require at /usr/local/bin/rip line 316.
[snip]
```
The error can be fixed by escaping these curly braces, what has been done in the this pull request. 

I would like to kindly ask you to incorporate this patch, which fixes the file `mountdev2.pl`. 

Best regards and thanks for providing regripper,
jgru