### PR TITLE
Fix compilation error in ScanButton.pl

### DIFF
--- a/plugins/ScanButton.pl
+++ b/plugins/ScanButton.pl
@@ -23,6 +23,9 @@ my %config = (hive          => "System",
               hasRefs       => 0,
               version       => 20131210);
 
+# Global symbol "%guid" requires explicit package name, to avoid compilation fail
+my %guid;
+
 sub getConfig{return %config}
 
 sub getShortDescr {


### PR DESCRIPTION
Dear Harlan,

this pull request fixes a compilation error in ScanButton.pl, which arised from not declaring the global symbol "%guid" explicitly. 

The following command 
```
rip -r share/system/System -p ScanButton             
```
led to this error message:
```
Error in /usr/local/share/regripper/plugins/ScanButton.pl: Global symbol "%guid" requires explicit package name (did you forget to declare "my %guid"?) at /usr/local/share/regripper/plugins/ScanButton.pl line 66.
Compilation failed in require at /usr/local/bin/rip line 316.
```

This can be fixed by declaring `%guid` explicitly. Testing on Ubuntu 18.04 and Debian Bullseye showed, that the plugin runs correct after applying this patch. 


Please consider to incorporate this pull request into `regripper`.
Thanks!

Best regards, 
jgru
