### PR TITLE
Modify the construction of the path to plugin directory

### DIFF
--- a/rip.pl
+++ b/rip.pl
@@ -8,6 +8,7 @@
 # Usage: see "_syntax()" function
 #
 # Change History
+#   20210612 - Clean up construction of plugin path
 #   20210302 - added Digest::MD5
 #   20200427 - added getDateFromEpoch(), output date format in RFC 3339 profile of ISO 8601
 #   20200331 - added "auto" capability...point rip at a hive, it determines the hive type and runs
@@ -35,6 +36,7 @@ use Getopt::Long;
 use Time::Local;
 use Digest::MD5;
 use File::Spec;
+use Cwd;
 
 # Included to permit compiling via Perl2Exe
 #perl2exe_include "Parse/Win32Registry.pm";
@@ -55,23 +57,12 @@ my %config;
 Getopt::Long::Configure("prefix_pattern=(-|\/)");
 GetOptions(\%config,qw(reg|r=s file|f=s csv|c dirty|d auto|a autoTLN|aT guess|g user|u=s sys|s=s plugin|p=s update|uP list|l help|?|h));
 
-# Code updated 20090102
-my @path;
-my $str = $0;
-($^O eq "MSWin32") ? (@path = split(/\\/,$0))
-                   : (@path = split(/\//,$0));
-$str =~ s/($path[scalar(@path) - 1])//;
+# Retrieves absolute path to executable 
+my $scriptpath = Cwd::realpath($0);
 
-# Suggested addition by Hal Pomeranz for compatibility with Linux
-#push(@INC,$str);
-# code updated 20190318
-my $plugindir;
-($^O eq "MSWin32") ? ($plugindir = $str."plugins/")
-                   : ($plugindir = File::Spec->catfile("plugins"));
-#my $plugindir = $str."plugins/";
-#my $plugindir = File::Spec->catfile("plugins");
-#print "Plugins Dir = ".$plugindir."\n";
-# End code update
+# Retrieves absolute path of parent directory 
+my $scriptdir = File::Basename::dirname($scriptpath);
+
 my $VERSION = "3\.0";
 my @alerts = ();
 


### PR DESCRIPTION
Dear Harlan, 

this patch modifies the construction of the path to the directory, where the plugins will be read from, in order to be more concise, while being platform independent. By constructing the path in this way, `rip.pl` will be fully functional, if it is called from a symlink.

Furthermore, this patch removes the misleading and erroneous code/comment snippets regarding the Linux usage.  
`push(@INC,$str);` just appended the directory to the include path, so that the patched files Base.pm, File.pm and Key.pm did not not take precedence over the system wide module. If used on Linux, I think, it is recommended to use `-I /path/to/modified/Parse/Win32registry/` or patch `rip.pl` with `use lib  /path/to/modified/Parse/Win32registry/` statement. 

Thank you already in advance for considering this pull request. 

Best regards,
Jan 
 