### PR TITLE
Add new plugin portproxy for reading port proxy key

### DIFF
--- a/plugins/portproxy.pl
+++ b/plugins/portproxy.pl
@@ -1,17 +1,23 @@
 #-----------------------------------------------------------
 # portproxy.pl
-#   Port proxy configuration used by netsh and attackers
-#   for command and control.
+#   Port proxy configuration used by netsh. Used by 
+#   attackers for command and control communication.
 #
-# History
+# Change History
 #   20210622 - created
 #
-# author: Andreas Hunkeler (@Karneades)
+# References
+#   https://www.fireeye.com/blog/threat-research/2019/01/bypassing-network-restrictions-through-rdp-tunneling.html
+#   https://adepts.of0x.cc/netsh-portproxy-code/
+#   https://www.dfirnotes.net/portproxy_detection/
+#
+# Author: Andreas Hunkeler (@Karneades)
 #-----------------------------------------------------------
 package portproxy;
 use strict;
 
 my %config = (hive          => "System",
+              category      => "config",
               osmask        => 22,
               hasShortDescr => 1,
               hasDescr      => 0,

--- a/plugins/portproxy.pl
+++ b/plugins/portproxy.pl
@@ -1,0 +1,65 @@
+#-----------------------------------------------------------
+# portproxy.pl
+#   Port proxy configuration used by netsh and attackers
+#   for command and control.
+#
+# History
+#   20210622 - created
+#
+# author: Andreas Hunkeler (@Karneades)
+#-----------------------------------------------------------
+package portproxy;
+use strict;
+
+my %config = (hive          => "System",
+              osmask        => 22,
+              hasShortDescr => 1,
+              hasDescr      => 0,
+              hasRefs       => 0,
+              version       => 20210622);
+
+sub getConfig{return %config}
+
+sub getShortDescr {
+	return "Get port proxy configuration from PortProxy key";
+}
+sub getDescr{}
+sub getRefs {}
+sub getHive {return $config{hive};}
+sub getVersion {return $config{version};}
+
+my $VERSION = getVersion();
+
+sub pluginmain {
+	my $class = shift;
+	my $hive = shift;
+	my %clsid;
+	::logMsg("Launching PortProxy v.".$VERSION);
+	::rptMsg("PortProxy v.".$VERSION); # banner
+	::rptMsg("(".$config{hive}.") ".getShortDescr()."\n"); # banner 
+	my $reg = Parse::Win32Registry->new($hive);
+	my $root_key = $reg->get_root_key;
+
+	my $key_path = "ControlSet001\\Services\\PortProxy\\v4tov4\\tcp";
+	my $key;
+	if ($key = $root_key->get_subkey($key_path)) {
+		::rptMsg($key_path);
+		::rptMsg("LastWrite Time ".::getDateFromEpoch($key->get_timestamp())."Z");
+		::rptMsg("");
+
+		my @vals = $key->get_list_of_values();
+		if (scalar(@vals) > 0) {
+			foreach my $v (@vals) {
+				::rptMsg($v->get_name()." - ".$v->get_data());
+				::rptMsg("");
+			}
+		}
+		else {
+			::rptMsg($key_path." has no values.");
+		}
+	}
+	else {
+		::rptMsg($key_path." not found.");
+	}
+}
+1;


### PR DESCRIPTION
Add new plugin for getting the port proxy configuration. Discussion in https://github.com/keydet89/RegRipper3.0/issues/35. Tested using RR 3.0 and SYSTEM hive from a Win 10 system.

Output
```
Processing hive ...\C\Windows\System32\config\SYSTEM_clean using plugin portproxy
Launching PortProxy v.20210622
PortProxy v.20210622
(System) Get port proxy configuration from PortProxy key

ControlSet001\Services\PortProxy\v4tov4\tcp
LastWrite Time 2021-06-22 13:51:13Z

0.0.0.0/1337 - 10.2.0.12/3389

0.0.0.0/1338 - 10.2.0.12/9876
```