### PR TITLE
Add AccessVBOM Value check

### DIFF
--- a/plugins/msoffice.pl
+++ b/plugins/msoffice.pl
@@ -146,6 +146,19 @@ sub pluginmain {
 			if (my $sec = $key->get_subkey($office_version."\\".$app."\\Security")) {
 				my $b = $sec->get_value("blockcontentexecutionfrominternet")->get_data();
 				::rptMsg("blockcontentexecutionfrominternet value: ".$b);
+				::rptMsg("");
+			}
+		};
+
+# Added 20221204
+# AccessVBOM subkey enables programmatic access to the VBA Object Model
+# Used in Zloader macros: https://www.mcafee.com/blogs/other-blogs/mcafee-labs/zloader-with-a-new-infection-technique/
+# https://renenyffenegger.ch/notes/development/languages/VBA/Programmatic-access-to-Visual-Basic-Project-is-not-trusted
+		eval {
+			if (my $sec = $key->get_subkey($office_version."\\".$app."\\Security")) {
+				my $vbom = $sec->get_value("AccessVBOM")->get_data();
+				::rptMsg("AccessVBOM value: ".$vbom);
+				::rptMsg("");
 			}
 		};
 

--- a/plugins/msoffice.pl
+++ b/plugins/msoffice.pl
@@ -151,7 +151,7 @@ sub pluginmain {
 		};
 
 # Added 20221204
-# AccessVBOM subkey enables programmatic access to the VBA Object Model
+# AccessVBOM value enables programmatic access to the VBA Object Model
 # Used in Zloader macros: https://www.mcafee.com/blogs/other-blogs/mcafee-labs/zloader-with-a-new-infection-technique/
 # https://renenyffenegger.ch/notes/development/languages/VBA/Programmatic-access-to-Visual-Basic-Project-is-not-trusted
 		eval {


### PR DESCRIPTION
This key enables programmatic access to the VBA object model. The value 1 is set when the user enables it in the Trust Center but it can also be enabled and abused by malware to run VBA code in a COM object or simply trust macro code ([Zloader](https://www.mcafee.com/blogs/other-blogs/mcafee-labs/zloader-with-a-new-infection-technique/), for example).